### PR TITLE
 fix: code highlighting for fenl

### DIFF
--- a/local-antora-playbook.yml
+++ b/local-antora-playbook.yml
@@ -5,8 +5,8 @@ site:
   # url: <TBD>
 content:
   sources:
-    - url: .
-      branches: docs-build
+    - url: ../kaskada
+      branches: main
       start_path: docs-src
       worktrees: true
 
@@ -26,6 +26,6 @@ asciidoc:
 
 ui:
   bundle:
-    url: https://gitlab.com/antora/antora-ui-default/-/jobs/artifacts/HEAD/raw/build/ui-bundle.zip?job=bundle-stable
+    url: ../docs-ui/build/ui-bundle.zip
     snapshot: true
   supplemental_files: ./supplemental-ui

--- a/package.json
+++ b/package.json
@@ -5,5 +5,12 @@
   },
   "dependencies": {
     "asciidoctor-kroki": "^0.16.0"
+  },
+  "scripts": {
+    "clean": "rm -rf build",
+    "cleanall": "rm -rf build node_modules",
+    "lb": "npx antora --fetch local-antora-playbook.yml --stacktrace",
+    "lbr": "npm install && npm run lb",
+    "rebuild": "npm run clean && npm run lb"
   }
 }

--- a/supplemental-ui/js/vendor/fenl.min.js
+++ b/supplemental-ui/js/vendor/fenl.min.js
@@ -1,0 +1,20 @@
+/*! `fenl` grammar compiled for Highlight.js 11.7.0 */
+(()=>{var e=(()=>{"use strict";return e=>{const n=e.regex,a={
+className:"title.function.invoke",relevance:0,
+begin:n.concat(/\b/,/(?!let|in\b)/,e.IDENT_RE,n.lookahead(/\s*\(/))
+},i="([ui](8|16|32|64|128|size)|f(32|64))?",s={className:"string",
+contains:[e.BACKSLASH_ESCAPE],variants:[e.APOS_STRING_MODE,e.QUOTE_STRING_MODE]}
+;return{name:"Fenl",aliases:["fenl"],disableAutDetection:!0,keywords:{
+$pattern:e.IDENT_RE,
+type:["i8","i16","i32","i64","u8","u16","u32","u64","f32","f64","string","bool"],
+keyword:["$input","in","let"],literal:["true","false","null"],
+built_in:["if","lookup","when"]},illegal:"</",contains:[e.HASH_COMMENT_MODE,s,{
+className:"symbol",begin:/'[a-zA-Z_][a-zA-Z0-9_]*/},{className:"number",
+variants:[{begin:"\\b0b([01_]+)"+i},{begin:"\\b0o([0-7_]+)"+i},{
+begin:"\\b0x([A-Fa-f0-9_]+)"+i},{
+begin:"\\b(\\d[\\d_]*(\\.[0-9_]+)?([eE][+-]?[0-9_]+)?)"+i}],relevance:0},{
+begin:[/fn/,/\s+/,e.UNDERSCORE_IDENT_RE],className:{1:"keyword",
+3:"title.function"}},{className:"meta",begin:"#!?\\[",end:"\\]",contains:[{
+className:"string",begin:/"/,end:/"/}]},{
+begin:[/let/,/\s+/,e.UNDERSCORE_IDENT_RE],className:{1:"keyword",3:"variable"}
+},a]}}})();hljs.registerLanguage("fenl",e)})();

--- a/supplemental-ui/partials/footer-scripts.hbs
+++ b/supplemental-ui/partials/footer-scripts.hbs
@@ -1,0 +1,10 @@
+<script src="{{{uiRootPath}}}/js/site.js"></script>
+{{!--
+<script async src="{{{uiRootPath}}}/js/vendor/highlight.js"></script>
+--}}
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
+<script async src="{{{uiRootPath}}}/js/vendor/fenl.min.js"></script>
+<script>hljs.initHighlightingOnLoad();</script>
+{{#if env.SITE_SEARCH_PROVIDER}}
+{{> search-scripts}}
+{{/if}}


### PR DESCRIPTION
A few things to get this to work

1. removed the bundled highlightjs from antora-ui. This was an older version 
2. highlightjs is not a download on the client instead of bundled 
    1. this is temporary till we release fenl as a 3rd party highlightjs lib  *and* publish to npm 
3. Updates to footer-script to add necessary script tags. 
4. Updated local playbook for a more generic setup.
    * I will add documentation on how to setup and develop everything in a bit   