### PR TITLE
Add PR only workflow (no publish) 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,6 @@ jobs:
           path: |
             build/site
       - name: Publish to GitHub Pages
-        if: ${{ }}
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,9 +1,6 @@
-name: Publish to GitHub Pages
+name: PR
 on:
-  # Allow manual triggering of this workflow
-  workflow_dispatch:
-
-  push:
+  pull_request:
     branches: [main]
 
 # In cases of concurrent workflows running (consecutive pushes to PR)
@@ -13,14 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: write
-  pages: write
-  id-token: write
-
 jobs:
-  build:
+  pr_build:
+    name: PR Build (no publish)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -41,9 +33,3 @@ jobs:
           name: docs-site
           path: |
             build/site
-      - name: Publish to GitHub Pages
-        if: ${{ }}
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: build/site


### PR DESCRIPTION
Separate CI flow that only builds and does not alter pages in any way. 
This CI flow is *not* callable from other repos and is used to check changes to the files in this repo only. 
